### PR TITLE
Visual improvements and get_info improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ Source/visual_studio_2019/.vs/
 Source/visual_studio_2019/packages/
 Source/visual_studio_2019/x64/
 Source/visual_studio_2019/Pikifen.vcxproj.user
+Source/visual_studio_2019/Game_data
+Source/visual_studio_2019/User_data
 Source/codelite/Debug/
 Source/codelite/Release/
 Source/codelite/.codelite/

--- a/Manual/content/changelog.html
+++ b/Manual/content/changelog.html
@@ -43,7 +43,7 @@
       <li>
         Added a results screen.
         <ul>
-          <li>When the player finishes playing in an area, the results screen gives them some basic stats: time taken, treasure points obtained, treasure points available, enemies killed, enemies available, Pikmin born, and Pikmin deaths.</li>
+          <li>When the player finishes playing in an area, the results screen gives them some basic stats: time taken, treasure points obtained, treasure points available, enemies killed, enemies available, Pikmin born, Pikmin deaths, and if cheats were used.</li>
           <li>The player is also given the option to retry, keep playing after hours, or pick a different area.</li>
           <li>The results screen is entered when the player chooses to end the day via the pause menu, when the day time is over, or when all leaders are KO.
           <li>Added a new property for treasure types: <code>points</code>. Use this to specify how many points they are worth.</li>
@@ -57,9 +57,12 @@
         </ul>
       </li>
       <li>Add new data for the <code>get_info</code> script action: <code>x</code>, <code>y</code>, and <code>z</code>. Use these to get the object's coordinates. (Thanks Kman)</li>
+	  <li><code>get_info</code> can now use <code>mob_type</code> and <code>mob_category</code> in <code>on_damage</code>.</li>
+	  <li>Added<code>get_focus_info</code>. It functions similar to <code>get_info</code>, but get's the data from the focused mob. Script actions: <code>x</code>, <code>y</code>, <code>z</code>, <code>health</code>, <code>chomped_pikmin</code>, <code>latched_pikmin</code>, <code>latched_pikmin_weight</code>,</li>
       <li>Added new system assets: <code>bubble_box</code>, used to draw box-like bubbles in the HUD and menus, <code>focus_box</code>, used to show which GUI item is focused, and <code>more</code>, used for menus to indicate there's more content beyond.</li>
       <li>Holding Shift when the snapping mode is "nothing" will now snap to the grid. The snapping mode is now also saved to the options. Finally, Shift+Plus and Shift+Minus change the grid spacing. (Thanks Nutty171, Neo)</li>
       <li>The Beady Long Legs's logic was slightly cleaned up.</li>
+	  <li>Healthbars now smoothly transition to their target fill ratio.</li>
     </ul>
     
     <p><b>Compatibility warnings</b></p>

--- a/Source/source/controls.cpp
+++ b/Source/source/controls.cpp
@@ -209,6 +209,7 @@ void gameplay_state::handle_allegro_event(ALLEGRO_EVENT &ev) {
                 break;
                 
             } case MAKER_TOOL_HURT_MOB: {
+                game.states.results->used_debug = true;
                 mob* m = get_closest_mob_to_cursor();
                 if(m) {
                     m->set_health(
@@ -225,6 +226,7 @@ void gameplay_state::handle_allegro_event(ALLEGRO_EVENT &ev) {
                 
             } case MAKER_TOOL_NEW_PIKMIN: {
                 if(mobs.pikmin_list.size() < game.config.max_pikmin_in_field) {
+                    game.states.results->used_debug = true;
                     pikmin_type* new_pikmin_type =
                         game.mob_types.pikmin.begin()->second;
                         
@@ -249,6 +251,7 @@ void gameplay_state::handle_allegro_event(ALLEGRO_EVENT &ev) {
                 break;
                 
             } case MAKER_TOOL_TELEPORT: {
+                game.states.results->used_debug = true;
                 sector* mouse_sector =
                     get_sector(game.mouse_cursor_w, NULL, true);
                 if(mouse_sector) {

--- a/Source/source/drawing.cpp
+++ b/Source/source/drawing.cpp
@@ -514,19 +514,19 @@ void draw_fraction(
  */
 void draw_health(
     const point &center, const float ratio, 
-    const float radius, const bool just_chart
+    const float alpha, const float radius, const bool just_chart
 ) {
     ALLEGRO_COLOR c;
     if (ratio >= 0.5) {
-        c = al_map_rgb_f(1 - (ratio - 0.5) * 2, 1, 0);
+        c = al_map_rgba_f(1 - (ratio - 0.5) * 2, 1, 0, alpha);
     }
     else {
-        c = al_map_rgb_f(1, (ratio * 2), 0);
+        c = al_map_rgba_f(1, (ratio * 2), 0, alpha);
     }
 
     if (!just_chart) {
         al_draw_filled_circle(
-            center.x, center.y, radius, al_map_rgba(0, 0, 0, 128)
+            center.x, center.y, radius, al_map_rgba(0, 0, 0, 128 * alpha)
         );
     }
     al_draw_filled_pieslice(
@@ -534,7 +534,7 @@ void draw_health(
     );
     if (!just_chart) {
         al_draw_circle(
-            center.x, center.y, radius + 1, al_map_rgb(0, 0, 0), 2
+            center.x, center.y, radius + 1, al_map_rgba(0, 0, 0, alpha * 255), 2
         );
     }
 }

--- a/Source/source/drawing.cpp
+++ b/Source/source/drawing.cpp
@@ -500,18 +500,12 @@ void draw_fraction(
         ALLEGRO_ALIGN_CENTER, 0, (i2s(needed).c_str())
     );
 }
-
-
 /* ----------------------------------------------------------------------------
  * Draws a health wheel, with a pieslice that's fuller the more HP is full.
  * center:
  *   Center of the wheel.
- * health:
- *   Current amount of health of the mob
- *   whose health we're representing.
- * max_health:
- *   Maximum amount of health of the mob;
- *   health for when it's fully healed.
+ * ratio:
+ *   How much of the health wheel is being filled.
  * radius:
  *   Radius of the wheel (the whole wheel, not just the pieslice).
  * just_chart:
@@ -519,19 +513,18 @@ void draw_fraction(
  *   Used for leader HP on the HUD.
  */
 void draw_health(
-    const point &center,
-    const float health, const float max_health,
+    const point &center, const float ratio, 
     const float radius, const bool just_chart
 ) {
-    float ratio = health / max_health;
     ALLEGRO_COLOR c;
-    if(ratio >= 0.5) {
+    if (ratio >= 0.5) {
         c = al_map_rgb_f(1 - (ratio - 0.5) * 2, 1, 0);
-    } else {
+    }
+    else {
         c = al_map_rgb_f(1, (ratio * 2), 0);
     }
-    
-    if(!just_chart) {
+
+    if (!just_chart) {
         al_draw_filled_circle(
             center.x, center.y, radius, al_map_rgba(0, 0, 0, 128)
         );
@@ -539,13 +532,12 @@ void draw_health(
     al_draw_filled_pieslice(
         center.x, center.y, radius, -TAU / 4, -ratio * TAU, c
     );
-    if(!just_chart) {
+    if (!just_chart) {
         al_draw_circle(
             center.x, center.y, radius + 1, al_map_rgb(0, 0, 0), 2
         );
     }
 }
-
 
 /* ----------------------------------------------------------------------------
  * Draws a liquid sector.

--- a/Source/source/drawing.h
+++ b/Source/source/drawing.h
@@ -78,7 +78,7 @@ void draw_fraction(
     const size_t needed, const ALLEGRO_COLOR &color
 );
 void draw_health(
-    const point &center, const float ratio,
+    const point &center, const float ratio, const float alpha = 1, 
     const float radius = DEF_HEALTH_WHEEL_RADIUS,
     const bool just_chart = false
 );

--- a/Source/source/drawing.h
+++ b/Source/source/drawing.h
@@ -78,8 +78,8 @@ void draw_fraction(
     const size_t needed, const ALLEGRO_COLOR &color
 );
 void draw_health(
-    const point &center, const float health,
-    const float max_health, const float radius = DEF_HEALTH_WHEEL_RADIUS,
+    const point &center, const float ratio,
+    const float radius = DEF_HEALTH_WHEEL_RADIUS,
     const bool just_chart = false
 );
 void draw_liquid(

--- a/Source/source/game_states/gameplay/drawing.cpp
+++ b/Source/source/game_states/gameplay/drawing.cpp
@@ -263,8 +263,7 @@ void gameplay_state::draw_hud() {
         if(hud_items.get_draw_data(health_id, &i_center, &i_size)) {
             draw_health(
                 i_center,
-                mobs.leaders[l_nr]->health,
-                mobs.leaders[l_nr]->type->max_health,
+                mobs.leaders[l_nr]->smoothed_ratio,
                 std::min(i_size.x, i_size.y) * 0.4f,
                 true
             );
@@ -833,7 +832,7 @@ void gameplay_state::draw_ingame_text() {
                     mob_ptr->pos.y - mob_ptr->type->radius -
                     DEF_HEALTH_WHEEL_RADIUS - 4
                 ),
-                mob_ptr->health, mob_ptr->type->max_health
+                mob_ptr->smoothed_ratio
             );
         }
         

--- a/Source/source/game_states/gameplay/drawing.cpp
+++ b/Source/source/game_states/gameplay/drawing.cpp
@@ -263,7 +263,7 @@ void gameplay_state::draw_hud() {
         if(hud_items.get_draw_data(health_id, &i_center, &i_size)) {
             draw_health(
                 i_center,
-                mobs.leaders[l_nr]->smoothed_ratio,
+                mobs.leaders[l_nr]->smoothed_ratio, 1,
                 std::min(i_size.x, i_size.y) * 0.4f,
                 true
             );
@@ -824,7 +824,7 @@ void gameplay_state::draw_ingame_text() {
             mob_ptr->type->show_health &&
             !mob_ptr->hide &&
             mob_ptr->health < mob_ptr->type->max_health &&
-            mob_ptr->health > 0
+            mob_ptr->healthbar_alpha > 0
         ) {
             draw_health(
                 point(
@@ -832,7 +832,8 @@ void gameplay_state::draw_ingame_text() {
                     mob_ptr->pos.y - mob_ptr->type->radius -
                     DEF_HEALTH_WHEEL_RADIUS - 4
                 ),
-                mob_ptr->smoothed_ratio
+                mob_ptr->smoothed_ratio,
+                mob_ptr->healthbar_alpha
             );
         }
         

--- a/Source/source/game_states/gameplay/drawing.cpp
+++ b/Source/source/game_states/gameplay/drawing.cpp
@@ -1511,14 +1511,14 @@ void gameplay_state::draw_onion_menu() {
             onion_menu_type_struct* t_ptr = onion_menu->on_screen_types[t];
             
             if(t_ptr->pik_type->bmp_onion_icon) {
-                draw_bitmap(
+                draw_bitmap_in_box(
                     t_ptr->pik_type->bmp_onion_icon, i_center, i_size * 0.8f
                 );
             }
             
             if(!onion_menu->select_all) {
-                draw_textured_box(
-                    i_center, i_size, game.sys_assets.bmp_bubble_box
+                draw_bitmap_in_box(
+                    game.sys_assets.bmp_bubble_box, i_center, i_size
                 );
             }
         }
@@ -1588,13 +1588,13 @@ void gameplay_state::draw_onion_menu() {
         ) {
             onion_menu_type_struct* t_ptr = onion_menu->on_screen_types[t];
             
-            draw_bitmap(
+            draw_bitmap_in_box(
                 t_ptr->pik_type->bmp_icon, i_center, i_size * 0.8f
             );
             
             if(!onion_menu->select_all) {
-                draw_textured_box(
-                    i_center, i_size, game.sys_assets.bmp_bubble_box
+                draw_bitmap_in_box(
+                    game.sys_assets.bmp_bubble_box, i_center, i_size
                 );
             }
         }

--- a/Source/source/game_states/results.cpp
+++ b/Source/source/game_states/results.cpp
@@ -30,7 +30,8 @@ results_state::results_state() :
     pikmin_deaths(0),
     points_obtained(0),
     points_total(0),
-    time_taken(0.0f) {
+    time_taken(0.0f),
+    used_debug(false) {
     
 }
 
@@ -319,7 +320,17 @@ void results_state::load() {
         game.fonts.counter
     );
     menu_widgets.push_back(pikmin_deaths_widget);
-    
+    if (used_debug) {
+        menu_text* used_debug_widget =
+            new menu_text(
+                point(game.win_w * 0.30, game.win_h * 0.78),
+                point(game.win_w * 0.40, game.win_h * 0.10),
+                "Used debug commands!",
+                game.fonts.main, al_map_rgb(255, 192, 192), ALLEGRO_ALIGN_LEFT
+            );
+        menu_widgets.push_back(used_debug_widget);
+    }
+
     //Finishing touches.
     game.fade_mgr.start_fade(true, nullptr);
     set_selected_widget(back_widget);
@@ -341,6 +352,7 @@ void results_state::reset() {
     time_taken = 0.0f;
     can_continue = true;
     leader_ko = false;
+    used_debug = false;
 }
 
 

--- a/Source/source/game_states/results.h
+++ b/Source/source/game_states/results.h
@@ -38,6 +38,8 @@ public:
     size_t points_total;
     //How much time was taken.
     float time_taken;
+    //Did the player use debug commands?
+    bool used_debug;
     
     results_state();
     virtual void load();

--- a/Source/source/init.cpp
+++ b/Source/source/init.cpp
@@ -575,6 +575,15 @@ void init_mob_actions() {
         mob_action_runners::get_info,
         mob_action_loaders::get_info
     );
+
+    reg_param("variable name", MOB_ACTION_PARAM_STRING, true, false);
+    reg_param("info", MOB_ACTION_PARAM_STRING, true, false);
+    reg_action(
+        MOB_ACTION_GET_FOCUS_INFO,
+        "get_focus_info",
+        mob_action_runners::get_focus_info,
+        mob_action_loaders::get_focus_info
+    );
     
     reg_param("this mob's var name", MOB_ACTION_PARAM_STRING, true, false);
     reg_param("focused mob's var name", MOB_ACTION_PARAM_STRING, true, false);

--- a/Source/source/mob_script_action.cpp
+++ b/Source/source/mob_script_action.cpp
@@ -347,6 +347,42 @@ bool mob_action_loaders::get_info(mob_action_call &call) {
 }
 
 
+
+
+/* ----------------------------------------------------------------------------
+ * Loading code for the focused mob info getting script action.
+ * call:
+ *   Mob action call that called this.
+ */
+bool mob_action_loaders::get_focus_info(mob_action_call& call) {
+    if (call.args[1] == "chomped_pikmin") {
+        call.args[1] = i2s(MOB_ACTION_GET_INFO_CHOMPED_PIKMIN);
+    }
+    else if (call.args[1] == "health") {
+        call.args[1] = i2s(MOB_ACTION_GET_INFO_HEALTH);
+    }
+    else if (call.args[1] == "latched_pikmin") {
+        call.args[1] = i2s(MOB_ACTION_GET_INFO_LATCHED_PIKMIN);
+    }
+    else if (call.args[1] == "latched_pikmin_weight") {
+        call.args[1] = i2s(MOB_ACTION_GET_INFO_LATCHED_PIKMIN_WEIGHT);
+    }
+    else if (call.args[1] == "x") {
+        call.args[1] = i2s(MOB_ACTION_GET_INFO_X);
+    }
+    else if (call.args[1] == "y") {
+        call.args[1] = i2s(MOB_ACTION_GET_INFO_Y);
+    }
+    else if (call.args[1] == "z") {
+        call.args[1] = i2s(MOB_ACTION_GET_INFO_Z);
+    }
+    else {
+        report_enum_error(call, 1);
+        return false;
+    }
+    return true;
+}
+
 /* ----------------------------------------------------------------------------
  * Loading code for the "if" mob script action.
  * call:
@@ -1017,6 +1053,52 @@ void mob_action_runners::get_info(mob_action_run_data &data) {
     }
 }
 
+
+/* ----------------------------------------------------------------------------
+ * Code for the info obtaining focused mob script action.
+ * data:
+ *   Data about the action call.
+ */
+void mob_action_runners::get_focus_info(mob_action_run_data& data) {
+    string* var = &(data.m->vars[data.args[0]]);
+    size_t t = s2i(data.args[1]);
+
+    if (data.m->focused_mob == NULL) {
+        return;
+    }
+
+    switch (t) {
+    case MOB_ACTION_GET_INFO_CHOMPED_PIKMIN: {
+        *var = i2s(data.m->focused_mob->chomping_mobs.size());
+        break;
+
+    } case MOB_ACTION_GET_INFO_HEALTH: {
+        *var = i2s(data.m->focused_mob->health);
+        break;
+
+    } case MOB_ACTION_GET_INFO_LATCHED_PIKMIN: {
+        *var = i2s(data.m->focused_mob->get_latched_pikmin_amount());
+        break;
+
+    } case MOB_ACTION_GET_INFO_LATCHED_PIKMIN_WEIGHT: {
+        *var = i2s(data.m->focused_mob->get_latched_pikmin_weight());
+        break;
+
+    } case MOB_ACTION_GET_INFO_X: {
+        *var = f2s(data.m->focused_mob->pos.x);
+        break;
+
+    } case MOB_ACTION_GET_INFO_Y: {
+        *var = f2s(data.m->focused_mob->pos.y);
+        break;
+
+    } case MOB_ACTION_GET_INFO_Z: {
+        *var = f2s(data.m->focused_mob->z);
+        break;
+
+    } 
+    }
+}
 
 /* ----------------------------------------------------------------------------
  * Code for the decimal number randomization mob script action.

--- a/Source/source/mob_script_action.cpp
+++ b/Source/source/mob_script_action.cpp
@@ -971,6 +971,11 @@ void mob_action_runners::get_info(mob_action_run_data &data) {
         ) {
             *var = ((mob*) (data.custom_data_1))->type->category->name;
         }
+        else if (
+            data.call->parent_event == MOB_EV_DAMAGE
+            ) {
+            *var = ((mob*)(data.custom_data_2))->type->category->name;
+        }
         break;
         
     } case MOB_ACTION_GET_INFO_MOB_TYPE: {
@@ -982,6 +987,10 @@ void mob_action_runners::get_info(mob_action_run_data &data) {
             data.call->parent_event == MOB_EV_THROWN_PIKMIN_LANDED
         ) {
             *var = ((mob*) (data.custom_data_1))->type->name;
+        } else if (
+            data.call->parent_event == MOB_EV_DAMAGE
+        ) {
+            *var = ((mob*)(data.custom_data_2))->type->name;
         }
         break;
         

--- a/Source/source/mob_script_action.h
+++ b/Source/source/mob_script_action.h
@@ -30,6 +30,7 @@ enum MOB_ACTION_TYPES {
     MOB_ACTION_FOCUS,
     MOB_ACTION_GET_CHOMPED,
     MOB_ACTION_GET_INFO,
+    MOB_ACTION_GET_FOCUS_INFO,
     MOB_ACTION_GET_FOCUS_VAR,
     MOB_ACTION_GET_RANDOM_DECIMAL,
     MOB_ACTION_GET_RANDOM_INT,
@@ -269,6 +270,7 @@ void finish_dying(mob_action_run_data &data);
 void focus(mob_action_run_data &data);
 void get_chomped(mob_action_run_data &data);
 void get_info(mob_action_run_data &data);
+void get_focus_info(mob_action_run_data& data);
 void get_focus_var(mob_action_run_data &data);
 void get_random_decimal(mob_action_run_data &data);
 void get_random_int(mob_action_run_data &data);
@@ -329,6 +331,7 @@ bool arachnorb_plan_logic(mob_action_call &call);
 bool calculate(mob_action_call &call);
 bool focus(mob_action_call &call);
 bool get_info(mob_action_call &call);
+bool get_focus_info(mob_action_call& call);
 bool if_function(mob_action_call &call);
 bool move_to_target(mob_action_call &call);
 bool receive_status(mob_action_call &call);

--- a/Source/source/mobs/mob.cpp
+++ b/Source/source/mobs/mob.cpp
@@ -2288,15 +2288,6 @@ void mob::tick(const float delta_t) {
         game.perf_mon->finish_measurement();
     }
     if(to_delete) return;
-    //Heath Ratio.
-    if (game.perf_mon) {
-        game.perf_mon->start_measurement("Object -- Health Ratio");
-    }
-    tick_health(delta_t);
-    if (game.perf_mon) {
-        game.perf_mon->finish_measurement();
-    }
-    if (to_delete) return;
 
     //Script.
     if(game.perf_mon) {
@@ -2352,40 +2343,6 @@ void mob::tick_animation(const float delta_t) {
     if(parent && parent->limb_anim.anim_db) {
         parent->limb_anim.tick(delta_t* mult);
     }
-}
-
-/* ----------------------------------------------------------------------------
- * Ticks one frame of health wheel ratio change
- * delta_t:
- *   How many seconds to tick by.
- */
-void mob::tick_health(const float delta_t) {
-    float amount = 1 * delta_t;
-
-    float ratio = health / type->max_health;
-    
-    // No need to edit smoothed ratio if it already equals the ratio
-    if (smoothed_ratio == ratio) {
-        return;
-    }
-    
-    float difference = ratio - smoothed_ratio;
-    if (difference < 0) {
-        difference *= -1;
-    }
-
-    if (difference < amount) {
-        smoothed_ratio = ratio;
-    }
-    else {
-        if (ratio > smoothed_ratio) {
-            smoothed_ratio += amount;
-        }
-        else {
-            smoothed_ratio -= amount;
-        }
-    }
-
 }
 
 /* ----------------------------------------------------------------------------
@@ -2545,6 +2502,27 @@ void mob::tick_misc_logic(const float delta_t) {
     if(type->blocks_carrier_pikmin && health <= 0) {
         game.states.gameplay->path_mgr.handle_obstacle_clear(this);
     }
+
+    float amount = 1 * delta_t;
+    float ratio = health / type->max_health;
+
+    float difference = ratio - smoothed_ratio;
+    if (difference < 0) {
+        difference *= -1;
+    }
+
+    if (difference < amount) {
+        smoothed_ratio = ratio;
+    }
+    else {
+        if (ratio > smoothed_ratio) {
+            smoothed_ratio += amount;
+        }
+        else {
+            smoothed_ratio -= amount;
+        }
+    }
+
 }
 
 

--- a/Source/source/mobs/mob.cpp
+++ b/Source/source/mobs/mob.cpp
@@ -2503,13 +2503,13 @@ void mob::tick_misc_logic(const float delta_t) {
         game.states.gameplay->path_mgr.handle_obstacle_clear(this);
     }
 
-    float amount = 1 * delta_t;
     float ratio = health / type->max_health;
-
-    float difference = ratio - smoothed_ratio;
+    float difference =  ratio - smoothed_ratio;
     if (difference < 0) {
         difference *= -1;
     }
+
+    float amount = (0.1f + difference * 6) * delta_t;
 
     if (difference < amount) {
         smoothed_ratio = ratio;

--- a/Source/source/mobs/mob.cpp
+++ b/Source/source/mobs/mob.cpp
@@ -74,9 +74,10 @@ mob::mob(const point &pos, mob_type* type, const float angle) :
     group_spot_index(INVALID),
     carry_info(nullptr),
     delivery_info(nullptr),
+    smoothed_ratio(1),
+    healthbar_alpha(1),
     id(next_mob_id),
     health(type->max_health),
-    smoothed_ratio(1),
     invuln_period(0),
     team(MOB_TEAM_NONE),
     hide(false),
@@ -2505,24 +2506,28 @@ void mob::tick_misc_logic(const float delta_t) {
 
     float ratio = health / type->max_health;
     float difference =  ratio - smoothed_ratio;
+    float ratio_amount = 1.5f * delta_t;
+
     if (difference < 0) {
         difference *= -1;
     }
 
-    float amount = (0.1f + difference * 6) * delta_t;
+    if (health <= 0) {
+        ratio_amount *= 3;
+        if (smoothed_ratio <= 0) {
+            healthbar_alpha -= 3 * delta_t;
+        }
+    }
 
-    if (difference < amount) {
+    if (difference < ratio_amount) {
         smoothed_ratio = ratio;
-    }
-    else {
+    } else {
         if (ratio > smoothed_ratio) {
-            smoothed_ratio += amount;
-        }
-        else {
-            smoothed_ratio -= amount;
+            smoothed_ratio += ratio_amount;
+        } else {
+            smoothed_ratio -= ratio_amount;
         }
     }
-
 }
 
 

--- a/Source/source/mobs/mob.cpp
+++ b/Source/source/mobs/mob.cpp
@@ -180,7 +180,7 @@ void mob::apply_attack_damage(
         set_health(true, false, -damage);
         
         hitbox_interaction ev_info(this, victim_h, attack_h);
-        fsm.run_event(MOB_EV_DAMAGE, (void*) &ev_info);
+        fsm.run_event(MOB_EV_DAMAGE, (void*) &ev_info, (void*) attacker);
         
         attacker->cause_spike_damage(this, false);
     }

--- a/Source/source/mobs/mob.h
+++ b/Source/source/mobs/mob.h
@@ -422,8 +422,6 @@ protected:
     ) const;
     //Tick its animation logic.
     void tick_animation(const float delta_t);
-    //Tick its health wheel.
-    void tick_health(const float delta_t);
     //Tick the mob's "thinking" logic.
     void tick_brain(const float delta_t);
     //Tick its horizontal movement physics logic.

--- a/Source/source/mobs/mob.h
+++ b/Source/source/mobs/mob.h
@@ -232,6 +232,8 @@ public:
     size_t id;
     //Current health.
     float health;
+    //Slowly moves to the current percentage of health a mob has.
+    float smoothed_ratio;
     //During this period, the mob cannot be attacked.
     timer invuln_period;
     //Mob's team (who it can damage); use MOB_TEAM_*.
@@ -420,6 +422,8 @@ protected:
     ) const;
     //Tick its animation logic.
     void tick_animation(const float delta_t);
+    //Tick its health wheel.
+    void tick_health(const float delta_t);
     //Tick the mob's "thinking" logic.
     void tick_brain(const float delta_t);
     //Tick its horizontal movement physics logic.

--- a/Source/source/mobs/mob.h
+++ b/Source/source/mobs/mob.h
@@ -227,13 +227,17 @@ public:
     //List of mobs it is holding.
     vector<mob*> holding;
     
+    //Healthbar things
+    //Slowly moves to the current percentage of health a mob has. 
+    float smoothed_ratio;
+    //Affects how visible the healthbar is when drawn, decreases to 0 while health <= 0
+    float healthbar_alpha;
+
     //Other properties.
     //Incremental ID. Used for minor things.
     size_t id;
     //Current health.
     float health;
-    //Slowly moves to the current percentage of health a mob has.
-    float smoothed_ratio;
     //During this period, the mob cannot be attacked.
     timer invuln_period;
     //Mob's team (who it can damage); use MOB_TEAM_*.

--- a/Source/visual_studio_2019/Pikifen.vcxproj
+++ b/Source/visual_studio_2019/Pikifen.vcxproj
@@ -168,15 +168,16 @@
     <ClInclude Include="..\source\const.h" />
     <ClInclude Include="..\source\controls.h" />
     <ClInclude Include="..\source\drawing.h" />
-    <ClInclude Include="..\source\game_states\animation_editor\editor.h" />
-    <ClInclude Include="..\source\game_states\area_editor\editor.h" />
-    <ClInclude Include="..\source\game_states\editor.h" />
     <ClInclude Include="..\source\functions.h" />
     <ClInclude Include="..\source\game.h" />
+	<ClInclude Include="..\source\game_states\animation_editor\editor.h" />
+    <ClInclude Include="..\source\game_states\area_editor\editor.h" />
+	<ClInclude Include="..\source\game_states\editor.h" />
     <ClInclude Include="..\source\game_states\gameplay\gameplay.h" />
+	<ClInclude Include="..\source\game_states\game_state.h" />
+	<ClInclude Include="..\source\game_states\menus.h" />
 	<ClInclude Include="..\source\game_states\results.h" />
     <ClInclude Include="..\source\game_config.h" />
-    <ClInclude Include="..\source\game_states\game_state.h" />
 	<ClInclude Include="..\source\gui.h" />
     <ClInclude Include="..\source\hazard.h" />
     <ClInclude Include="..\source\hitbox.h" />
@@ -191,7 +192,6 @@
     <ClInclude Include="..\source\init.h" />
     <ClInclude Include="..\source\liquid.h" />
     <ClInclude Include="..\source\load.h" />
-    <ClInclude Include="..\source\game_states\menus.h" />
     <ClInclude Include="..\source\menu_widgets.h" />
     <ClInclude Include="..\source\misc_structs.h" />
     <ClInclude Include="..\source\mobs\bouncer.h" />
@@ -293,32 +293,30 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\source\animation.cpp" />
-	<ClCompile Include="..\source\game_states\area_menu.cpp" />
-	<ClCompile Include="..\source\game_states\controls_menu.cpp" />
-	<ClCompile Include="..\source\game_states\main_menu.cpp" />
-	<ClCompile Include="..\source\game_states\options_menu.cpp" />
     <ClCompile Include="..\source\controls.cpp" />
     <ClCompile Include="..\source\drawing.cpp" />
-    <ClCompile Include="..\source\game_states\animation_editor\drawing.cpp" />
+    <ClCompile Include="..\source\functions.cpp" />
+    <ClCompile Include="..\source\game.cpp" />
+	<ClCompile Include="..\source\game_config.cpp" />
+	<ClCompile Include="..\source\game_states\animation_editor\drawing.cpp" />
     <ClCompile Include="..\source\game_states\animation_editor\editor.cpp" />
     <ClCompile Include="..\source\game_states\animation_editor\event_handling.cpp" />
     <ClCompile Include="..\source\game_states\animation_editor\gui.cpp" />
-	
     <ClCompile Include="..\source\game_states\area_editor\drawing.cpp" />
     <ClCompile Include="..\source\game_states\area_editor\editor.cpp" />
     <ClCompile Include="..\source\game_states\area_editor\event_handling.cpp" />
     <ClCompile Include="..\source\game_states\area_editor\geometry_logic.cpp" />
     <ClCompile Include="..\source\game_states\area_editor\gui.cpp" />
-	
-    <ClCompile Include="..\source\game_states\editor.cpp" />
-    <ClCompile Include="..\source\functions.cpp" />
-    <ClCompile Include="..\source\game.cpp" />
-    <ClCompile Include="..\source\game_states\gameplay\gameplay.cpp" />
-	<ClCompile Include="..\source\game_states\gameplay\logic.cpp" />
+	<ClCompile Include="..\source\game_states\area_menu.cpp" />
+	<ClCompile Include="..\source\game_states\controls_menu.cpp" />
+	<ClCompile Include="..\source\game_states\editor.cpp" />
 	<ClCompile Include="..\source\game_states\gameplay\drawing.cpp" />
+	<ClCompile Include="..\source\game_states\gameplay\gameplay.cpp" />
+	<ClCompile Include="..\source\game_states\gameplay\logic.cpp" />
+	<ClCompile Include="..\source\game_states\game_state.cpp" />
+	<ClCompile Include="..\source\game_states\main_menu.cpp" />
+	<ClCompile Include="..\source\game_states\options_menu.cpp" />
 	<ClCompile Include="..\source\game_states\results.cpp" />
-    <ClCompile Include="..\source\game_config.cpp" />
-    <ClCompile Include="..\source\game_states\game_state.cpp" />
 	<ClCompile Include="..\source\gui.cpp" />
     <ClCompile Include="..\source\hazard.cpp" />
     <ClCompile Include="..\source\hitbox.cpp" />

--- a/Source/visual_studio_2019/Pikifen.vcxproj
+++ b/Source/visual_studio_2019/Pikifen.vcxproj
@@ -168,14 +168,16 @@
     <ClInclude Include="..\source\const.h" />
     <ClInclude Include="..\source\controls.h" />
     <ClInclude Include="..\source\drawing.h" />
-    <ClInclude Include="..\source\editors\animation_editor\editor.h" />
-    <ClInclude Include="..\source\editors\area_editor\editor.h" />
-    <ClInclude Include="..\source\editors\editor.h" />
+    <ClInclude Include="..\source\game_states\animation_editor\editor.h" />
+    <ClInclude Include="..\source\game_states\area_editor\editor.h" />
+    <ClInclude Include="..\source\game_states\editor.h" />
     <ClInclude Include="..\source\functions.h" />
     <ClInclude Include="..\source\game.h" />
-    <ClInclude Include="..\source\gameplay.h" />
+    <ClInclude Include="..\source\game_states\gameplay\gameplay.h" />
+	<ClInclude Include="..\source\game_states\results.h" />
     <ClInclude Include="..\source\game_config.h" />
-    <ClInclude Include="..\source\game_state.h" />
+    <ClInclude Include="..\source\game_states\game_state.h" />
+	<ClInclude Include="..\source\gui.h" />
     <ClInclude Include="..\source\hazard.h" />
     <ClInclude Include="..\source\hitbox.h" />
     <ClInclude Include="..\source\imgui\imconfig.h" />
@@ -189,7 +191,7 @@
     <ClInclude Include="..\source\init.h" />
     <ClInclude Include="..\source\liquid.h" />
     <ClInclude Include="..\source\load.h" />
-    <ClInclude Include="..\source\menus.h" />
+    <ClInclude Include="..\source\game_states\menus.h" />
     <ClInclude Include="..\source\menu_widgets.h" />
     <ClInclude Include="..\source\misc_structs.h" />
     <ClInclude Include="..\source\mobs\bouncer.h" />
@@ -291,23 +293,33 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\source\animation.cpp" />
+	<ClCompile Include="..\source\game_states\area_menu.cpp" />
+	<ClCompile Include="..\source\game_states\controls_menu.cpp" />
+	<ClCompile Include="..\source\game_states\main_menu.cpp" />
+	<ClCompile Include="..\source\game_states\options_menu.cpp" />
     <ClCompile Include="..\source\controls.cpp" />
     <ClCompile Include="..\source\drawing.cpp" />
-    <ClCompile Include="..\source\editors\animation_editor\drawing.cpp" />
-    <ClCompile Include="..\source\editors\animation_editor\editor.cpp" />
-    <ClCompile Include="..\source\editors\animation_editor\event_handling.cpp" />
-    <ClCompile Include="..\source\editors\animation_editor\gui.cpp" />
-    <ClCompile Include="..\source\editors\area_editor\drawing.cpp" />
-    <ClCompile Include="..\source\editors\area_editor\editor.cpp" />
-    <ClCompile Include="..\source\editors\area_editor\event_handling.cpp" />
-    <ClCompile Include="..\source\editors\area_editor\geometry_logic.cpp" />
-    <ClCompile Include="..\source\editors\area_editor\gui.cpp" />
-    <ClCompile Include="..\source\editors\editor.cpp" />
+    <ClCompile Include="..\source\game_states\animation_editor\drawing.cpp" />
+    <ClCompile Include="..\source\game_states\animation_editor\editor.cpp" />
+    <ClCompile Include="..\source\game_states\animation_editor\event_handling.cpp" />
+    <ClCompile Include="..\source\game_states\animation_editor\gui.cpp" />
+	
+    <ClCompile Include="..\source\game_states\area_editor\drawing.cpp" />
+    <ClCompile Include="..\source\game_states\area_editor\editor.cpp" />
+    <ClCompile Include="..\source\game_states\area_editor\event_handling.cpp" />
+    <ClCompile Include="..\source\game_states\area_editor\geometry_logic.cpp" />
+    <ClCompile Include="..\source\game_states\area_editor\gui.cpp" />
+	
+    <ClCompile Include="..\source\game_states\editor.cpp" />
     <ClCompile Include="..\source\functions.cpp" />
     <ClCompile Include="..\source\game.cpp" />
-    <ClCompile Include="..\source\gameplay.cpp" />
+    <ClCompile Include="..\source\game_states\gameplay\gameplay.cpp" />
+	<ClCompile Include="..\source\game_states\gameplay\logic.cpp" />
+	<ClCompile Include="..\source\game_states\gameplay\drawing.cpp" />
+	<ClCompile Include="..\source\game_states\results.cpp" />
     <ClCompile Include="..\source\game_config.cpp" />
-    <ClCompile Include="..\source\game_state.cpp" />
+    <ClCompile Include="..\source\game_states\game_state.cpp" />
+	<ClCompile Include="..\source\gui.cpp" />
     <ClCompile Include="..\source\hazard.cpp" />
     <ClCompile Include="..\source\hitbox.cpp" />
     <ClCompile Include="..\source\imgui\imgui.cpp" />
@@ -319,9 +331,7 @@
     <ClCompile Include="..\source\init.cpp" />
     <ClCompile Include="..\source\liquid.cpp" />
     <ClCompile Include="..\source\load.cpp" />
-    <ClCompile Include="..\source\logic.cpp" />
     <ClCompile Include="..\source\main.cpp" />
-    <ClCompile Include="..\source\menus.cpp" />
     <ClCompile Include="..\source\menu_widgets.cpp" />
     <ClCompile Include="..\source\misc_structs.cpp" />
     <ClCompile Include="..\source\mobs\bouncer.cpp" />


### PR DESCRIPTION
Overview of what has been changed:
Visual Changes:
- Health bar changes to act more like Pikmin 3
  - Health bars smoothly transition to their target fill ratio. Health bars drain faster if the mob's current health is 0
  - Health bars fade out when the fill ratio is 0 instead of disappearing instantly when they die.
- Results screen now shows a text box if certain maker tools were used .
   - Tools that will cause this to appear: `MAKER_TOOL_NEW_PIKMIN`, `MAKER_TOOL_HURT_MOB`, and `MAKER_TOOL_TELEPORT`. `MAKER_TOOL_CHANGE_SPEED` affects the results timer as well, so there is no gameplay benefit to using it, which is why it is not included
- The onion menu's Pikmin, onion, and single bubble sprite are no longer stretched with different aspect ratios

Scripting Changes:
- `get_focus_info` has been added, it works like `get_info` except targets the user's focused mob. 
  - Can use the parameters: `health`, `chomped_pikmin`, `latched_pikmin`, `latched_pikmin_weight`, `x`, `y`, and `z`
- `get_info` `mob_category` and `mob_type` can now be used in the `on_damage` event
  - This would have done for hitbox events, but hitboxes don't posses a reference to the mob that owns them

Misc. Changes:
- Updated gitignore to include User_data and Game_data in the solution's folder (makes testing changes on windows easier)
- Updated vcxproj to work with latest commit
- Changelog updated to include new changes