### PR TITLE
Fix Pikmin return to leader after dropping a tool.

### DIFF
--- a/Source/source/mob_fsms/pikmin_fsm.cpp
+++ b/Source/source/mob_fsms/pikmin_fsm.cpp
@@ -1835,6 +1835,8 @@ void pikmin_fsm::begin_pluck(mob* m, void* info1, void* info2) {
  *   Unused.
  */
 void pikmin_fsm::called(mob* m, void* info1, void* info2) {
+    engine_assert(info1 != NULL, m->print_state_history());
+
     pikmin* pik = (pikmin*) m;
     leader* caller = (leader*) info1;
     
@@ -1864,6 +1866,8 @@ void pikmin_fsm::called(mob* m, void* info1, void* info2) {
  *   Unused.
  */
 void pikmin_fsm::called_while_knocked_down(mob* m, void* info1, void* info2) {
+    engine_assert(info1 != NULL, m->print_state_history());
+
     pikmin* pik = (pikmin*) m;
     leader* caller = (leader*) info1;
     
@@ -2660,7 +2664,7 @@ void pikmin_fsm::land_on_mob_while_holding(mob* m, void* info1, void* info2) {
         }
         
         if(too_ptr->too_type->pikmin_returns_after_using) {
-            pikmin_fsm::called(m, NULL, NULL);
+            pikmin_fsm::called(m, game.states.gameplay->cur_leader_ptr, NULL);
             m->fsm.set_state(PIKMIN_STATE_IN_GROUP_CHASING);
         }
     }
@@ -2693,7 +2697,7 @@ void pikmin_fsm::land_while_holding(mob* m, void* info1, void* info2) {
         m->fsm.set_state(PIKMIN_STATE_IDLING);
         
         if(too_ptr->too_type->pikmin_returns_after_using) {
-            pikmin_fsm::called(m, NULL, NULL);
+            pikmin_fsm::called(m, game.states.gameplay->cur_leader_ptr, NULL);
             m->fsm.set_state(PIKMIN_STATE_IN_GROUP_CHASING);
         }
     } else {


### PR DESCRIPTION
- pikmin_fsm::called expects the leader as info1, which was not the case after a Pikmin would drop a tool with "pikmin_returns_after_using" set.
- Ensure that the Pikmin returns to the current leader, instead of returning to the origin or crashing.

The attached area triggers a crash when you:
1. Whistle to call the Pikmin and Bomb Rock
2. Move the leader from the origin in any direction
3. Throw the Pikmin either into a random area, or onto the enemy

The Pikmin will return to the origin (0, 0) even if that's not where the Leader is, and then the engine will crash.

```
Program crash!
  Reason: Signal 11 (Segmentation fault: 11).
  Info: Backtrace:
    0   pikifen                             0x000000010bae8a3e get_backtrace() + + 78
    1   pikifen                             0x000000010baf2054 signal_handler(int) + + 68
    2   libsystem_platform.dylib            0x00007fff20397d7d _sigtramp + + 29
    3   ???                                 0xaaaaaaaaaaaaaaaa 0x0 + 12297829382473034410
    4   pikifen                             0x000000010b5c3f65 mob::tick_rotation_physics(float, float) + + 197
    5   pikifen                             0x000000010b5c3d3e mob::tick_physics(float) + + 222
    6   pikifen                             0x000000010b5dbb20 mob::tick(float) + + 400
    7   pikifen                             0x000000010b8f80ab gameplay_state::do_gameplay_logic() + + 1803
    8   pikifen                             0x000000010b941cba gameplay_state::do_logic() + + 218
    9   pikifen                             0x000000010bb29c22 game_class::main_loop() + + 386
    10  pikifen                             0x000000010bb0a982 _al_mangled_main + + 194
    11  liballegro.5.2.dylib                0x000000010d02e5cb call_user_main + 23
    12  liballegro.5.2.dylib                0x000000010d02e5b4 call_user_main + 0
    13  Foundation                          0x00007fff210fb437 __NSThread__start__ + + 1068
    14  libsystem_pthread.dylib             0x00007fff203528fc _pthread_start + + 224
    15  libsystem_pthread.dylib             0x00007fff2034e443 thread_start + 15
  Time: 2021/05/31 22:19:45.
  Game state: gameplay. delta_t: 0.0131 (76.3126 FPS).
  Mob count: 4. Particle count: 14.
  Bitmaps loaded: 170 (1134 total calls).
  Current area: return-to-leader, version .
  Current leader: Olimar, at -125.0162 -103.1847, state history: active holding active whistling
  10 closest Pikmin to that leader:
    Red Pikmin, at -1.1653 -2.6886, history: in_group_stopped in_group_chasing idling thrown_h

```

The root cause appears to be that in commit 1559bc, `pikmin_fsb::called` was changed:

```
@@ -1761,12 +1824,13 @@ void pikmin_fsm::begin_pluck(mob* m, void* info1, void* info2) {
  * m:
  *   The mob.
  * info1:
- *   Unused.
+ *   Pointer to the leader that called.
  * info2:
  *   Unused.
  */
 void pikmin_fsm::called(mob* m, void* info1, void* info2) {
     pikmin* pik = (pikmin*) m;
+    leader* caller = (leader*) info1;
     
     for(size_t s = 0; s < m->statuses.size(); ++s) {
         if(m->statuses[s].type->removable_with_whistle) {
@@ -1778,11 +1842,44 @@ void pikmin_fsm::called(mob* m, void* info1, void* info2) {
     pik->was_last_hit_dud = false;
     pik->consecutive_dud_hits = 0;
     
-    game.states.gameplay->cur_leader_ptr->add_to_group(pik);
+    caller->add_to_group(pik);
     game.sys_assets.sfx_pikmin_called.play(0.03, false);
 }
```

However, there are tools like Bomb Rock that have `pikmin_returns_after_using` set, which causes:

```
        if(too_ptr->too_type->pikmin_returns_after_using) {
            pikmin_fsm::called(m, NULL, NULL);
            m->fsm.set_state(PIKMIN_STATE_IN_GROUP_CHASING);
        }
```

There are two codepaths (either `land_on_mob_while_holding` or `land_while_holding`) which call `pikmin_fsm::called()` with a `NULL` leader, and effectively called `NULL->add_to_group(pik);`. The Pikmin would end up walking back to the origin (0,0) and then try to turn to face the same direction as its group leader (which was `nullptr`) and end up crashing.

I added explicit assertions so that a Pikmin doesn't attempt to be called to a non-existent leader, and also changed these explicit callsites to pass in the current leader in the game. Even if the user switches to another leader after throwing the Pikmin, it seems preferable to having the Pikmin walk to the origin and crash.

[return-to-leader.zip](https://github.com/Espyo/Pikifen/files/6573571/return-to-leader.zip)

