### PR TITLE
Add CXXFLAGS to find allegro when installed in a dedicated path

### DIFF
--- a/Source/gnu_make/makefile
+++ b/Source/gnu_make/makefile
@@ -5,8 +5,9 @@ CC           := g++
 SRCS         := $(shell find Source/source -name '*.cpp')
 OBJS         := $(SRCS:.cpp=.o)
 DEPS         := $(OBJS:.o=.d)
-CXXFLAGS     := -std=c++0x -rdynamic -D_GLIBCXX_USE_CXX11_ABI=0 -MMD
-LDFLAGS      += -lm `pkg-config --libs allegro-5 allegro_main-5 allegro_audio-5 allegro_image-5 allegro_font-5 allegro_acodec-5 allegro_primitives-5 allegro_dialog-5`
+ALLEGRO_PKGS := allegro-5 allegro_main-5 allegro_audio-5 allegro_image-5 allegro_font-5 allegro_acodec-5 allegro_primitives-5 allegro_dialog-5
+CXXFLAGS     := -std=c++0x -rdynamic -D_GLIBCXX_USE_CXX11_ABI=0 -MMD $(shell pkg-config --cflags $(ALLEGRO_PKGS))
+LDFLAGS      += -lm $(shell pkg-config --libs $(ALLEGRO_PKGS))
 DEBUGFLAGS   := -g -ggdb -Wall -Wno-unknown-pragmas -O0
 RELEASEFLAGS := -Wall -Wextra -Wno-unknown-pragmas -O2
 


### PR DESCRIPTION
I develop primarily on macOS, and installed Allegro using Homebrew, which puts the headers and libraries in the following paths:

```
$ pkg-config --cflags allegro-5
-I/opt/brew/Cellar/allegro/5.2.7.0/include
$ pkg-config --libs allegro-5
-L/opt/brew/Cellar/allegro/5.2.7.0/lib -lallegro
```

Since this isn't in one of the default paths (e.g. `/usr/local/include`), the build fails. The makefiles already support consulting `pkg-config` for libraries, I added support for cflags as well. To make sure I didn't break anything, I also tested this on Ubuntu 20.04 (Focal Fossa) with GCC 9.3.0 and the release and debug builds continued to work fine.

I've also been using Address Sanitizer to investigate crashes, so I added an `asan` configuration that builds with optimization disabled and the Address sanitizer enabled. I tested this on macOS 11, as well as Ubuntu (using both GCC 9.3.0 and Clang 10.0 with `CC=clang++ CXX=clang++`). On Ubuntu, ASan found some leaks on exit, so I can tell it's working.