### PR TITLE
Fix some issues found by UBSan

### DIFF
--- a/Source/source/functions.cpp
+++ b/Source/source/functions.cpp
@@ -10,8 +10,10 @@
 
 #define _USE_MATH_DEFINES
 
-//Disable warning about localtime being deprecated.
-#pragma warning(disable : 4996)
+// Visual Studio warnings
+#ifdef _MSC_VER
+#pragma warning(disable : 4996)     // Disable warning about localtime being deprecated
+#endif
 
 #include <algorithm>
 #include <iostream>

--- a/Source/source/mob_types/mob_type.cpp
+++ b/Source/source/mob_types/mob_type.cpp
@@ -336,7 +336,7 @@ void load_mob_type_from_file(
         vector<string> words = split(vuln_node->value);
         float percentage = mt->default_vulnerability;
         string status_name;
-        bool status_overrides;
+        bool status_overrides = false;
         if(!words.empty()) {
             percentage = s2f(words[0]);
         }

--- a/Source/source/utils/data_file.cpp
+++ b/Source/source/utils/data_file.cpp
@@ -255,7 +255,7 @@ size_t data_node::load_node(
 ) {
     children.clear();
     
-    if(start_line > lines.size()) return start_line;
+    if(start_line >= lines.size()) return start_line;
     
     bool returning_from_sub_node = false;
     


### PR DESCRIPTION
- When a final "vulnerabilities" word is not given, initialize override to false
- When a non-existent data file is accessed, exit early if there are no lines to parse
- Fix pragma to be under _MSC_VER guard

I enabled UBSan on macOS and encountered two issues. The first was when parsing the "vulnerabilities" config line:

```
/Users/shantonu/Documents/Pikifen/Source/source/mob_types/mob_type.cpp:372:37: runtime error: load of value 16, which is not a valid value for type 'bool'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/shantonu/Documents/Pikifen/Source/source/mob_types/mob_type.cpp:372:37 in 
```

This is because of this code:

```
        bool status_overrides;
        if(!words.empty()) {
            percentage = s2f(words[0]);
        }
        if(words.size() >= 2) {
            status_name = words[1];
        }
        if(words.size() >= 3) {
            status_overrides = s2b(words[2]);
        }
...
            vuln.status_overrides = status_overrides;
        }
```

Based on the documentation:

> The third word, also optional, controls whether the status effect overrides others. If true, then the object will only receive the status effect from the previous word, and will not receive the status effect the hazard usually gives. If false or not specified, then the object will also receive this status effect on top of any others the hazard gives.

I initialized `status_overrides` to `false` if it's not provided.

I also ran into:
```
/Users/shantonu/Documents/Pikifen/Source/source/utils/data_file.cpp:337:25: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'unsigned long'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/shantonu/Documents/Pikifen/Source/source/utils/data_file.cpp:337:25 in 
```

I had extra unsigned integer checks enabled, and I believe this is because the engine was trying to load `Game_data/Types/Pikmin/Blue/Script.txt` (which doesn't exist), and then call `data_node::load_node` with an empty vector:

```
size_t data_node::load_node(
    const vector<string> &lines, const bool trim_values,
    const size_t start_line, const size_t depth,
    const bool names_only_after_root
) {
    children.clear();
    
    if(start_line > lines.size()) return start_line;
    
    bool returning_from_sub_node = false;
    
    for(size_t l = start_line; l < lines.size(); ++l) {
        string line = lines[l];
...
    }
    return lines.size() - 1;
```

Even though the `for` loop doesn't deference the vector inappropriately, I believe the intent here was to return `0` on empty vectors to indicate nothing had been parsed, instead of returning `(unsigned long)-1`, which doesn't really make any sense.

I also noticed some warning pragmas that should only be used for MS Visual Studio