### PR TITLE
Fixed error logs sometimes not showing.

### DIFF
--- a/Source/source/functions.cpp
+++ b/Source/source/functions.cpp
@@ -1010,7 +1010,7 @@ void log_error(string s, data_node* d) {
     string output = "";
     if(game.errors_reported_so_far == 0) {
         string first_error_info =
-            "Pikifen version " +
+            "> Pikifen version " +
             i2s(VERSION_MAJOR) + "." + i2s(VERSION_MINOR) +
             "." + i2s(VERSION_REV);
         if(!game.config.version.empty()) {
@@ -1020,13 +1020,13 @@ void log_error(string s, data_node* d) {
         first_error_info += ":\n";
         output += first_error_info;
     }
-    output += "\t" + get_current_time(false) + ": " + s;
+    output += get_current_time(false) + ": " + s;
     if(d) {
         output += " (" + d->file_name;
         if (d->line_nr != 0) output += " line " + i2s(d->line_nr);
         output += ")";
     }
-
+    output += "\n";
     std::cout << output;
     
     string prev_error_log;
@@ -1038,6 +1038,7 @@ void log_error(string s, data_node* d) {
             getline(file_i, line);
             prev_error_log += line + "\n";
         }
+        prev_error_log.erase(prev_error_log.size() - 1);
         al_fclose(file_i);
     }
     

--- a/Source/source/functions.cpp
+++ b/Source/source/functions.cpp
@@ -1007,28 +1007,27 @@ ALLEGRO_COLOR interpolate_color(
  *   and line that caused the error.
  */
 void log_error(string s, data_node* d) {
-    if(d) {
-        s += " (" + d->file_name;
-        if(d->line_nr != 0) s += " line " + i2s(d->line_nr);
-        s += ")";
-    }
-    s += "\n";
-    
-    std::cout << s;
-    
+    string output = "";
     if(game.errors_reported_so_far == 0) {
-        s =
-            "\n" +
-            get_current_time(false) +
-            "; Pikifen version " +
+        string first_error_info =
+            "Pikifen version " +
             i2s(VERSION_MAJOR) + "." + i2s(VERSION_MINOR) +
             "." + i2s(VERSION_REV);
         if(!game.config.version.empty()) {
-            s +=
-                ", game version " +
-                game.config.version + "\n" + s;
+            first_error_info +=
+                ", " + game.config.name + " version " + game.config.version;
         }
+        first_error_info += ":\n";
+        output += first_error_info;
     }
+    output += "\t" + get_current_time(false) + ": " + s;
+    if(d) {
+        output += " (" + d->file_name;
+        if (d->line_nr != 0) output += " line " + i2s(d->line_nr);
+        output += ")";
+    }
+
+    std::cout << output;
     
     string prev_error_log;
     string line;
@@ -1039,14 +1038,13 @@ void log_error(string s, data_node* d) {
             getline(file_i, line);
             prev_error_log += line + "\n";
         }
-        prev_error_log.erase(prev_error_log.size() - 1);
         al_fclose(file_i);
     }
     
     ALLEGRO_FILE* file_o =
         al_fopen(ERROR_LOG_FILE_PATH.c_str(), "w");
     if(file_o) {
-        al_fwrite(file_o, prev_error_log + s);
+        al_fwrite(file_o, prev_error_log + output);
         al_fclose(file_o);
     }
     

--- a/Source/source/mob_types/pellet_type.cpp
+++ b/Source/source/mob_types/pellet_type.cpp
@@ -69,7 +69,9 @@ void pellet_type::load_properties(data_node* file) {
             pik_type_node
         );
     }
-    pik_type = game.mob_types.pikmin[pik_type_str];
+    else {
+        pik_type = game.mob_types.pikmin[pik_type_str];
+    }
     
     weight = number;
 }


### PR DESCRIPTION
This Pull Request patches a bug where error logs would sometimes not show

Also, fixes a crash where a pellet having a non-existent Pikmin type would cause a crash