### PR TITLE
Bug fixes

### DIFF
--- a/Game_data/Types/Enemies/Skutterchuck/Script.txt
+++ b/Game_data/Types/Enemies/Skutterchuck/Script.txt
@@ -4,6 +4,7 @@ death_state = dying
 init {
     set_var ignoring false
     set_var has_nodule false
+    set_var throw_range 250
 }
 
 script {
@@ -200,6 +201,18 @@ script {
         on_enter {
             stop
             set_animation preparing
+            load_focused_mob_memory 2
+        }
+        on_tick {
+            get_focus_info target_x x
+            get_focus_info target_y y
+            get_focus_info target_z z		
+            get_info self_x x
+            get_info self_y y
+            get_distance dist $self_x $self_y $target_x $target_y				
+            if $dist > $throw_range	
+                set_state looking_for_target
+            end_if
         }
         on_animation_end {
             set_state flinging
@@ -214,12 +227,8 @@ script {
             set_animation flinging
         }
         on_frame_signal {
-            load_focused_mob_memory 2
-            get_focus_info x x
-            get_focus_info y y
-            get_focus_info z z
             load_focused_mob_memory 1
-            throw_focused_mob $x $y $z 300
+            throw_focused_mob $target_x $target_y $target_z 300
             send_message_to_focus be_flung
             set_var has_nodule false
         }

--- a/Source/source/game_states/gameplay/gameplay.cpp
+++ b/Source/source/game_states/gameplay/gameplay.cpp
@@ -872,6 +872,7 @@ void gameplay_state::load() {
         if(game.cur_area_data.mission.goal_all_mobs) {
             for(size_t m = 0; m < mobs_per_gen.size(); ++m) {
                 if(
+                    mobs_per_gen[m] &&
                     game.mission_goals[game.cur_area_data.mission.goal]->
                     is_mob_applicable(mobs_per_gen[m]->type)
                 ) {

--- a/Source/source/game_states/gameplay/logic.cpp
+++ b/Source/source/game_states/gameplay/logic.cpp
@@ -886,7 +886,7 @@ void gameplay_state::do_gameplay_logic(const float delta_t) {
             last_pikmin_death_pos = point(LARGE_FLOAT, LARGE_FLOAT);
             last_ship_that_got_treasure_pos = point(LARGE_FLOAT, LARGE_FLOAT);
             
-            mission_score = 0;
+            mission_score = game.cur_area_data.mission.starting_points;
             for(size_t c = 0; c < game.mission_score_criteria.size(); ++c) {
                 if(
                     !has_flag(

--- a/Source/source/game_states/results.cpp
+++ b/Source/source/game_states/results.cpp
@@ -248,7 +248,7 @@ void results_state::load() {
         (MISSION_FAIL_CONDITIONS) INVALID;
         
     //Calculate score things.
-    final_mission_score = 0;
+    final_mission_score = game.cur_area_data.mission.starting_points;
     
     for(size_t c = 0; c < game.mission_score_criteria.size(); ++c) {
         mission_score_criterion* c_ptr =
@@ -616,6 +616,17 @@ void results_state::load() {
     stats_scroll->list_item = stats_list;
     gui.add_item(stats_scroll, "stats_scroll");
     
+    if(game.cur_area_data.type == AREA_TYPE_MISSION &&
+        game.cur_area_data.mission.starting_points != 0
+    ) {
+        //Starting score bullet.
+        add_stat(
+            "Starting score: ",
+            i2s(game.cur_area_data.mission.starting_points),
+            COLOR_GOLD
+        );
+    }
+
     //Time taken bullet.
     unsigned int ds =
         fmod(game.states.gameplay->gameplay_time_passed * 10, 10);

--- a/Source/source/init.cpp
+++ b/Source/source/init.cpp
@@ -548,7 +548,11 @@ void init_event_things(
         );
         game.display = al_create_display(game.win_w, game.win_h);
     }
-    
+
+    //For some reason some resolutions aren't properly created
+    //Fix that here.
+    al_resize_display(game.display, game.win_w, game.win_h);
+
     if(!game.display) {
         report_fatal_error("Could not create a display!");
     }

--- a/Source/source/init.cpp
+++ b/Source/source/init.cpp
@@ -1407,7 +1407,8 @@ void init_mob_actions() {
         nullptr
     );
     
-    reg_param("angle", MOB_ACTION_PARAM_FLOAT, false, false);
+    reg_param("angle or x coordinate", MOB_ACTION_PARAM_FLOAT, false, false);
+    reg_param("y coordinate", MOB_ACTION_PARAM_FLOAT, false, true);
     reg_action(
         MOB_ACTION_TURN_TO_RELATIVE,
         "turn_to_relative",

--- a/Source/source/load.cpp
+++ b/Source/source/load.cpp
@@ -259,14 +259,14 @@ void load_area(
             )->get_child_by_name("s", s);
         sector* new_sector = new sector();
         
-        new_sector->type =
-            (SECTOR_TYPES)
+        size_t new_type = 
             game.sector_types.get_idx(
                 sector_data->get_child_by_name("type")->value
             );
-        if((size_t) new_sector->type == INVALID) {
-            new_sector->type = SECTOR_TYPE_NORMAL;
+        if(new_type == INVALID) {
+            new_type = SECTOR_TYPE_NORMAL;
         }
+        new_sector->type = (SECTOR_TYPES)new_type;
         new_sector->is_bottomless_pit =
             s2b(
                 sector_data->get_child_by_name(

--- a/Source/source/mobs/mob_physics.cpp
+++ b/Source/source/mobs/mob_physics.cpp
@@ -779,8 +779,8 @@ void mob::tick_vertical_movement_physics(
         //https://youtu.be/hG9SzQxaCm8
         z +=
             (speed_z * delta_t) +
-            ((MOB::GRAVITY_ADDER / 2.0f) * delta_t* delta_t);
-        speed_z += MOB::GRAVITY_ADDER * delta_t;
+            ((MOB::GRAVITY_ADDER * gravity_mult / 2.0f) * delta_t * delta_t);
+        speed_z += MOB::GRAVITY_ADDER * delta_t * gravity_mult;
     }
     
     //Landing.

--- a/Source/source/mobs/mob_physics.cpp
+++ b/Source/source/mobs/mob_physics.cpp
@@ -438,11 +438,6 @@ void mob::tick_horizontal_movement_physics(
             new_ground_sector = new_center_sector;
         }
         
-        if(z < new_center_sector->z) {
-            //If it'd end up under the ground, refuse the move.
-            return;
-        }
-        
         //Get all edges it collides against in this new position.
         vector<edge*> intersecting_edges;
         if(

--- a/Source/source/mobs/mob_utils.cpp
+++ b/Source/source/mobs/mob_utils.cpp
@@ -1327,6 +1327,14 @@ void delete_mob(mob* m_ptr, const bool complete_destruction) {
                 m_ptr->release(m2_ptr);
                 m2_ptr->stored_inside_another = NULL;
             }
+            if(m2_ptr->carry_info) {
+                for(size_t c = 0; c < m2_ptr->carry_info->spot_info.size(); ++c) {
+                    if(m2_ptr->carry_info->spot_info[c].pik_ptr == m_ptr) {
+                        m2_ptr->carry_info->spot_info[c].pik_ptr = NULL;
+                        m2_ptr->carry_info->spot_info[c].state = CARRY_SPOT_FREE;
+                    }
+                }
+            }
         }
         
         if(m_ptr->holder.m) {


### PR DESCRIPTION
- Fixed carry spots sometimes not being cleared on Pikmin death
- Fixed some resolutions having inaccurate interaction boxes
- Fixed gravity multiplier not being used
- Fixed sectors without a type loading as an invalid sector type
- Fixed Skutterchucks having infinite throw range
- Fixed `turn_to_relative <x> <y>` throwing errors