### PR TITLE
get_onion_info

### DIFF
--- a/Manual/content/events_and_actions.html
+++ b/Manual/content/events_and_actions.html
@@ -645,6 +645,27 @@
           </dd>
         </dl></td>
       </tr>
+	  <th><code>get_onion_info</code></th>
+        <td><dl>
+          <dt><code><b>get_onion_info</b> &lt;destination_variable_name&gt; &lt;target&gt; &lt;information&gt; [&lt;argument1&gt;] [&lt;argument2&gt;]</code></dt>
+          <dd>
+            Sets the variable &lt;destination_variable_name&gt; to some special information about a given object from the Onion category. The possible target types are:
+            <ul>
+              <li><code><b>self</b></code>: The object that the script belongs to.</li>
+              <li><code><b>focus</b></code>: The object that is currently focused. The action does nothing if none is focused.</li>
+              <li><code><b>trigger</b></code>: The object that triggered the event. The action does nothing if this is not applicable.</li>
+            </ul>
+			
+            The possible data are:
+            <ul>
+              <li><code><b>pikmin_amount</b></code>: Requires argument1 and argument2, returns the amount of a specific pikmin type and maturity stored in an onion. 
+e.g: pikmin_inside "Red Pikmin" 0 for leaf red pikmin inside the onion. </li>
+              <li><code><b>pikmin_types</b></code>: Requires argument1, returns if a specific type is allowed in the onion. Returns "true" or "false"
+e.g: pikmin_types "Red Pikmin" to check if Red Pikmin are allowed in the onion </li>
+            </ul>
+          </dd>
+        </dl></td>
+      </tr>
     </table>
     
     <h3 id="actions-var-manipulation">Variable manipulation</h3>

--- a/Source/source/init.cpp
+++ b/Source/source/init.cpp
@@ -995,6 +995,18 @@ void init_mob_actions() {
         mob_action_runners::get_mob_info,
         mob_action_loaders::get_mob_info
     );
+
+    reg_param("destination var name", MOB_ACTION_PARAM_STRING, true, false);
+    reg_param("target", MOB_ACTION_PARAM_STRING, true, false);
+    reg_param("info", MOB_ACTION_PARAM_STRING, true, false);
+    reg_param("argument1", MOB_ACTION_PARAM_STRING, true, true);
+    reg_param("argument2", MOB_ACTION_PARAM_STRING, true, true);
+    reg_action(
+        MOB_ACTION_GET_ONION_INFO,
+        "get_onion_info",
+        mob_action_runners::get_onion_info,
+        mob_action_loaders::get_onion_info
+    );
     
     reg_param("destination var name", MOB_ACTION_PARAM_STRING, true, false);
     reg_param("minimum value", MOB_ACTION_PARAM_FLOAT, false, false);

--- a/Source/source/mob_script_action.h
+++ b/Source/source/mob_script_action.h
@@ -80,6 +80,9 @@ enum MOB_ACTION {
     
     //Get information about a mob.
     MOB_ACTION_GET_MOB_INFO,
+
+    //Get information about a mob of the onion category.
+    MOB_ACTION_GET_ONION_INFO,
     
     //Get a random decimal number.
     MOB_ACTION_GET_RANDOM_DECIMAL,
@@ -458,6 +461,15 @@ enum MOB_ACTION_GET_MOB_INFO_TYPE {
     
 };
 
+//Get onion info action info types.
+enum MOB_ACTION_GET_ONION_INFO_TYPE {
+    //Get Pikmin inside.
+    MOB_ACTION_GET_ONION_INFO_PIKMIN_INSIDE,
+
+    //Get Pikmin allowed in the onion.
+    MOB_ACTION_GET_ONION_INFO_PIKMIN_TYPES,
+
+};
 
 //Moving action sub-types.
 enum MOB_ACTION_MOVE_TYPE {
@@ -702,6 +714,7 @@ void get_event_info(mob_action_run_data &data);
 void get_area_info(mob_action_run_data &data);
 void get_floor_z(mob_action_run_data &data);
 void get_mob_info(mob_action_run_data &data);
+void get_onion_info(mob_action_run_data& data);
 void get_focus_var(mob_action_run_data &data);
 void get_random_decimal(mob_action_run_data &data);
 void get_random_int(mob_action_run_data &data);
@@ -776,6 +789,7 @@ bool focus(mob_action_call &call);
 bool get_area_info(mob_action_call &call);
 bool get_event_info(mob_action_call &call);
 bool get_mob_info(mob_action_call &call);
+bool get_onion_info(mob_action_call &call);
 bool hold_focus(mob_action_call &call);
 bool if_function(mob_action_call &call);
 bool move_to_target(mob_action_call &call);


### PR DESCRIPTION
Adds get_onion_info into the game, a new script tool similar to get_mob_info that gets information exclusive to onions.

The pr contains a premade manual entry.