### PR TITLE
Improvements to onion shaders

### DIFF
--- a/source/source/content/mob/mob_utils.cpp
+++ b/source/source/content/mob/mob_utils.cpp
@@ -1167,18 +1167,22 @@ void PikminNestType::createColormap() {
     KeyframeInterpolator<ALLEGRO_COLOR> ki(pikTypes[0]->mainColor);
     float span = 1;
     if(pikTypes.size() > 1) {
-        span = 1.0f / (pikTypes.size() - 1);
+        span = 1.0f / pikTypes.size();
     }
     for(size_t i = 1; i < pikTypes.size(); i++) {
         ki.addNew(span * i, pikTypes[i]->mainColor, EASE_METHOD_IN_OUT);
     }
     
-    //Add a darker variant for single-type Onions.
     if(pikTypes.size() == 1) {
+        //Add a darker variant for single-type Onions.
         ALLEGRO_COLOR c =
             tintColor(pikTypes[0]->mainColor, mapGray(0.40f * 255));
-        ki.addNew(1.0, c, EASE_METHOD_IN_OUT);
-    }
+        ki.addNew(0.5, c, EASE_METHOD_IN_OUT);
+    } 
+    //Readd the first color at the end to allow smooth looping
+    ALLEGRO_COLOR c =
+        pikTypes[0]->mainColor;
+    ki.addNew(1.0, c, EASE_METHOD_IN_OUT);
     
     //Create the texture.
     ALLEGRO_BITMAP* oldTargetBmp = al_get_target_bitmap();

--- a/source/source/core/shaders_source.cpp
+++ b/source/source/core/shaders_source.cpp
@@ -582,15 +582,13 @@ float noise(vec3 v) {
                                     dot(p2,x2), dot(p3,x3) ) );
 }
 
-float color(vec2 xy, float time_scale) { return noise(vec3(1.5*xy, time_scale * area_time)); }
+float color(vec2 xy, float time_scale) { return noise(vec3(xy, time_scale * area_time)); }
 
 float simplex_noise(vec2 xy, float noise_scale, vec2 step, float time_scale) {
     float x = 0;
-    x += 0.5 * color(xy * 2.0 * noise_scale - step, time_scale);
-    x += 0.25 * color(xy * 4.0 * noise_scale - 2.0 * step, time_scale);
-    x += 0.125 * color(xy * 8.0 * noise_scale - 4.0 * step, time_scale);
-    x += 0.0625 * color(xy * 16.0 * noise_scale - 6.0 * step, time_scale);
-    x += 0.03125 * color(xy * 32.0 * noise_scale - 8.0 * step, time_scale);
+    x += 0.5 * color(xy * 3.0 * noise_scale - step, time_scale);
+    x += 0.25 * color(xy * 6.0 * noise_scale - 2.0 * step, time_scale);
+    x += 0.125 * color(xy * 12.0 * noise_scale - 4.0 * step, time_scale);
     return x;
 }
 
@@ -611,7 +609,9 @@ void main() {
     //Calculate simplex noise effects.
     float raw_noise_value = simplex_noise(varying_texcoord, noise_func_scale, noise_func_step, 0.02);
     raw_noise_value = simplex_noise(varying_texcoord + raw_noise_value, noise_func_scale, noise_func_step, 0.02);
-    vec4 final_pixel = texture(colormap, vec2((raw_noise_value + 0.2) * 2.5, 0));
+    
+    //I have no idea what the range for simplex_noise is, so instead use some magic numbers that look good, and loop the colormap.
+    vec4 final_pixel = texture(colormap, vec2(fract((raw_noise_value + 0.2) * 2.5), 0));
     final_pixel.a = alpha;
     final_pixel.r *= brightness;
     final_pixel.g *= brightness;

--- a/source/source/core/shaders_source.cpp
+++ b/source/source/core/shaders_source.cpp
@@ -13,7 +13,6 @@
 
 namespace SHADER_SOURCES {
 
-
 #pragma region Default vertex shader
 
 
@@ -480,115 +479,78 @@ uniform float brightness;
  * ========================
  */
 
-//
-// Description : Array and textureless GLSL 2D/3D/4D simplex
-//               noise functions.
-//      Author : Ian McEwan, Ashima Arts.
-//  Maintainer : stegu
-//     Lastmod : 20201014 (stegu)
-//     License : Copyright (C) 2011 Ashima Arts. All rights reserved.
-//               Distributed under the MIT License. See LICENSE file.
-//               https://github.com/ashima/webgl-noise
-//               https://github.com/stegu/webgl-noise
-//
+// psrdnoise (c) Stefan Gustavson and Ian McEwan,
+// ver. 2021-12-02, published under the MIT license:
+// https://github.com/stegu/psrdnoise/
 
-vec3 mod289(vec3 x) {
-    return x - floor(x * (1.0 / 289.0)) * 289.0;
+vec4 permute(vec4 i) {
+     vec4 im = mod(i, 289.0);
+     return mod(((im*34.0)+10.0)*im, 289.0);
 }
 
-vec4 mod289(vec4 x) {
-    return x - floor(x * (1.0 / 289.0)) * 289.0;
+//Output is [-1, 1]
+float psrdnoise(vec3 x, vec3 period, float alpha)
+{
+  const mat3 M = mat3(0.0, 1.0, 1.0, 1.0, 0.0, 1.0,  1.0, 1.0, 0.0);
+  const mat3 Mi = mat3(-0.5, 0.5, 0.5, 0.5,-0.5, 0.5, 0.5, 0.5,-0.5);
+  vec3 uvw = M * x;
+  vec3 i0 = floor(uvw), f0 = fract(uvw);
+  vec3 g_ = step(f0.xyx, f0.yzz), l_ = 1.0 - g_;
+  vec3 g = vec3(l_.z, g_.xy), l = vec3(l_.xy, g_.z);
+  vec3 o1 = min( g, l ), o2 = max( g, l );
+  vec3 i1 = i0 + o1, i2 = i0 + o2, i3 = i0 + vec3(1.0);
+  vec3 v0 = Mi * i0, v1 = Mi * i1, v2 = Mi * i2, v3 = Mi * i3;
+  vec3 x0 = x - v0, x1 = x - v1, x2 = x - v2, x3 = x - v3;
+  if(any(greaterThan(period, vec3(0.0)))) {
+    vec4 vx = vec4(v0.x, v1.x, v2.x, v3.x);
+    vec4 vy = vec4(v0.y, v1.y, v2.y, v3.y);
+    vec4 vz = vec4(v0.z, v1.z, v2.z, v3.z);
+	if(period.x > 0.0) vx = mod(vx, period.x);
+	if(period.y > 0.0) vy = mod(vy, period.y);
+	if(period.z > 0.0) vz = mod(vz, period.z);
+	i0 = floor(M * vec3(vx.x, vy.x, vz.x) + 0.5);
+	i1 = floor(M * vec3(vx.y, vy.y, vz.y) + 0.5);
+	i2 = floor(M * vec3(vx.z, vy.z, vz.z) + 0.5);
+	i3 = floor(M * vec3(vx.w, vy.w, vz.w) + 0.5);
+  }
+  vec4 hash = permute( permute( permute( 
+              vec4(i0.z, i1.z, i2.z, i3.z ))
+            + vec4(i0.y, i1.y, i2.y, i3.y ))
+            + vec4(i0.x, i1.x, i2.x, i3.x ));
+  vec4 theta = hash * 3.883222077;
+  vec4 sz = hash * -0.006920415 + 0.996539792;
+  vec4 psi = hash * 0.108705628;
+  vec4 Ct = cos(theta), St = sin(theta);
+  vec4 sz_prime = sqrt( 1.0 - sz*sz );
+  vec4 gx, gy, gz;
+  if(alpha != 0.0) {
+    vec4 px = Ct * sz_prime, py = St * sz_prime, pz = sz;
+    vec4 Sp = sin(psi), Cp = cos(psi), Ctp = St*Sp - Ct*Cp;
+    vec4 qx = mix( Ctp*St, Sp, sz), qy = mix(-Ctp*Ct, Cp, sz);
+    vec4 qz = -(py*Cp + px*Sp);
+    vec4 Sa = vec4(sin(alpha)), Ca = vec4(cos(alpha));
+    gx = Ca*px + Sa*qx; gy = Ca*py + Sa*qy; gz = Ca*pz + Sa*qz;
+  }
+  else {
+    gx = Ct * sz_prime; gy = St * sz_prime; gz = sz;  
+  }
+  vec3 g0 = vec3(gx.x, gy.x, gz.x), g1 = vec3(gx.y, gy.y, gz.y);
+  vec3 g2 = vec3(gx.z, gy.z, gz.z), g3 = vec3(gx.w, gy.w, gz.w);
+  vec4 w = 0.5-vec4(dot(x0,x0), dot(x1,x1), dot(x2,x2), dot(x3,x3));
+  w = max(w, 0.0); vec4 w2 = w * w, w3 = w2 * w;
+  vec4 gdotx = vec4(dot(g0,x0), dot(g1,x1), dot(g2,x2), dot(g3,x3));
+  float n = dot(w3, gdotx);
+  return 39.5 * n;
 }
 
-vec4 permute(vec4 x) {
-    return mod289(((x*34.0)+10.0)*x);
-}
-
-vec4 taylor_inv_sqrt(vec4 r) {
-    return 1.79284291400159 - 0.85373472095314 * r;
-}
-
-float noise(vec3 v) {
-    const vec2  C = vec2(1.0/6.0, 1.0/3.0) ;
-    const vec4  D = vec4(0.0, 0.5, 1.0, 2.0);
-
-    // First corner
-    vec3 i  = floor(v + dot(v, C.yyy) );
-    vec3 x0 =   v - i + dot(i, C.xxx) ;
-
-    // Other corners
-    vec3 g = step(x0.yzx, x0.xyz);
-    vec3 l = 1.0 - g;
-    vec3 i1 = min( g.xyz, l.zxy );
-    vec3 i2 = max( g.xyz, l.zxy );
-
-    //   x0 = x0 - 0.0 + 0.0 * C.xxx;
-    //   x1 = x0 - i1  + 1.0 * C.xxx;
-    //   x2 = x0 - i2  + 2.0 * C.xxx;
-    //   x3 = x0 - 1.0 + 3.0 * C.xxx;
-    vec3 x1 = x0 - i1 + C.xxx;
-    vec3 x2 = x0 - i2 + C.yyy; // 2.0*C.x = 1/3 = C.y
-    vec3 x3 = x0 - D.yyy;      // -1.0+3.0*C.x = -0.5 = -D.y
-
-    // Permutations
-    i = mod289(i);
-    vec4 p = permute( permute( permute(
-                i.z + vec4(0.0, i1.z, i2.z, 1.0 ))
-            + i.y + vec4(0.0, i1.y, i2.y, 1.0 ))
-            + i.x + vec4(0.0, i1.x, i2.x, 1.0 ));
-
-    // Gradients: 7x7 points over a square, mapped onto an octahedron.
-    // The ring size 17*17 = 289 is close to a multiple of 49 (49*6 = 294)
-    float n_ = 0.142857142857; // 1.0/7.0
-    vec3  ns = n_ * D.wyz - D.xzx;
-
-    vec4 j = p - 49.0 * floor(p * ns.z * ns.z);  //  mod(p,7*7)
-
-    vec4 x_ = floor(j * ns.z);
-    vec4 y_ = floor(j - 7.0 * x_ );    // mod(j,N)
-
-    vec4 x = x_ *ns.x + ns.yyyy;
-    vec4 y = y_ *ns.x + ns.yyyy;
-    vec4 h = 1.0 - abs(x) - abs(y);
-
-    vec4 b0 = vec4( x.xy, y.xy );
-    vec4 b1 = vec4( x.zw, y.zw );
-
-    //vec4 s0 = vec4(lessThan(b0,0.0))*2.0 - 1.0;
-    //vec4 s1 = vec4(lessThan(b1,0.0))*2.0 - 1.0;
-    vec4 s0 = floor(b0)*2.0 + 1.0;
-    vec4 s1 = floor(b1)*2.0 + 1.0;
-    vec4 sh = -step(h, vec4(0.0));
-
-    vec4 a0 = b0.xzyw + s0.xzyw*sh.xxyy ;
-    vec4 a1 = b1.xzyw + s1.xzyw*sh.zzww ;
-
-    vec3 p0 = vec3(a0.xy,h.x);
-    vec3 p1 = vec3(a0.zw,h.y);
-    vec3 p2 = vec3(a1.xy,h.z);
-    vec3 p3 = vec3(a1.zw,h.w);
-
-    //Normalize gradients
-    vec4 norm = taylor_inv_sqrt(vec4(dot(p0,p0), dot(p1,p1), dot(p2, p2), dot(p3,p3)));
-    p0 *= norm.x;
-    p1 *= norm.y;
-    p2 *= norm.z;
-    p3 *= norm.w;
-
-    // Mix final noise value
-    vec4 m = max(0.5 - vec4(dot(x0,x0), dot(x1,x1), dot(x2,x2), dot(x3,x3)), 0.0);
-    m = m * m;
-    return 105.0 * dot( m*m, vec4( dot(p0,x0), dot(p1,x1),
-                                    dot(p2,x2), dot(p3,x3) ) );
-}
-
-float color(vec2 xy, float time_scale) { return noise(vec3(xy, time_scale * area_time)); }
+float color(vec2 xy, float time_scale) { return psrdnoise(vec3(xy, time_scale * area_time), vec3(0,0,0), alpha * 0.3); }
 
 float simplex_noise(vec2 xy, float noise_scale, vec2 step, float time_scale) {
     float x = 0;
     x += 0.5 * color(xy * 3.0 * noise_scale - step, time_scale);
-    x += 0.25 * color(xy * 6.0 * noise_scale - 2.0 * step, time_scale);
-    x += 0.125 * color(xy * 12.0 * noise_scale - 4.0 * step, time_scale);
+    x += 0.25 * color(xy * 6.0 * noise_scale - 3.0 * step, time_scale);
+    x += 0.125 * color(xy * 12.0 * noise_scale - 4.5 * step, time_scale);
+    //x += 0.0625 * color(xy * 24.0 * noise_scale - 6.0 * step, time_scale);
     return x;
 }
 
@@ -610,8 +572,8 @@ void main() {
     float raw_noise_value = simplex_noise(varying_texcoord, noise_func_scale, noise_func_step, 0.02);
     raw_noise_value = simplex_noise(varying_texcoord + raw_noise_value, noise_func_scale, noise_func_step, 0.02);
     
-    //I have no idea what the range for simplex_noise is, so instead use some magic numbers that look good, and loop the colormap.
-    vec4 final_pixel = texture(colormap, vec2(fract((raw_noise_value + 0.2) * 2.5), 0));
+    //Even though simplex noise returns [-1, 1], multiplying and keeping the fraction lets more colors appear at once.
+    vec4 final_pixel = texture(colormap, vec2(fract(raw_noise_value * 2), 0));
     final_pixel.a = alpha;
     final_pixel.r *= brightness;
     final_pixel.g *= brightness;

--- a/source/source/core/shaders_source.cpp
+++ b/source/source/core/shaders_source.cpp
@@ -489,7 +489,8 @@ vec4 permute(vec4 i) {
 }
 
 //Output is [-1, 1]
-float psrdnoise(vec3 x, vec3 period, float alpha)
+//Alpha and period parameters cut from the source, as they are unused by the shader.
+float psrdnoise(vec3 x)
 {
   const mat3 M = mat3(0.0, 1.0, 1.0, 1.0, 0.0, 1.0,  1.0, 1.0, 0.0);
   const mat3 Mi = mat3(-0.5, 0.5, 0.5, 0.5,-0.5, 0.5, 0.5, 0.5,-0.5);
@@ -501,18 +502,6 @@ float psrdnoise(vec3 x, vec3 period, float alpha)
   vec3 i1 = i0 + o1, i2 = i0 + o2, i3 = i0 + vec3(1.0);
   vec3 v0 = Mi * i0, v1 = Mi * i1, v2 = Mi * i2, v3 = Mi * i3;
   vec3 x0 = x - v0, x1 = x - v1, x2 = x - v2, x3 = x - v3;
-  if(any(greaterThan(period, vec3(0.0)))) {
-    vec4 vx = vec4(v0.x, v1.x, v2.x, v3.x);
-    vec4 vy = vec4(v0.y, v1.y, v2.y, v3.y);
-    vec4 vz = vec4(v0.z, v1.z, v2.z, v3.z);
-	if(period.x > 0.0) vx = mod(vx, period.x);
-	if(period.y > 0.0) vy = mod(vy, period.y);
-	if(period.z > 0.0) vz = mod(vz, period.z);
-	i0 = floor(M * vec3(vx.x, vy.x, vz.x) + 0.5);
-	i1 = floor(M * vec3(vx.y, vy.y, vz.y) + 0.5);
-	i2 = floor(M * vec3(vx.z, vy.z, vz.z) + 0.5);
-	i3 = floor(M * vec3(vx.w, vy.w, vz.w) + 0.5);
-  }
   vec4 hash = permute( permute( permute( 
               vec4(i0.z, i1.z, i2.z, i3.z ))
             + vec4(i0.y, i1.y, i2.y, i3.y ))
@@ -522,18 +511,9 @@ float psrdnoise(vec3 x, vec3 period, float alpha)
   vec4 psi = hash * 0.108705628;
   vec4 Ct = cos(theta), St = sin(theta);
   vec4 sz_prime = sqrt( 1.0 - sz*sz );
-  vec4 gx, gy, gz;
-  if(alpha != 0.0) {
-    vec4 px = Ct * sz_prime, py = St * sz_prime, pz = sz;
-    vec4 Sp = sin(psi), Cp = cos(psi), Ctp = St*Sp - Ct*Cp;
-    vec4 qx = mix( Ctp*St, Sp, sz), qy = mix(-Ctp*Ct, Cp, sz);
-    vec4 qz = -(py*Cp + px*Sp);
-    vec4 Sa = vec4(sin(alpha)), Ca = vec4(cos(alpha));
-    gx = Ca*px + Sa*qx; gy = Ca*py + Sa*qy; gz = Ca*pz + Sa*qz;
-  }
-  else {
-    gx = Ct * sz_prime; gy = St * sz_prime; gz = sz;  
-  }
+  vec4 gx = Ct * sz_prime; 
+  vec4 gy = St * sz_prime; 
+  vec4 gz = sz;  
   vec3 g0 = vec3(gx.x, gy.x, gz.x), g1 = vec3(gx.y, gy.y, gz.y);
   vec3 g2 = vec3(gx.z, gy.z, gz.z), g3 = vec3(gx.w, gy.w, gz.w);
   vec4 w = 0.5-vec4(dot(x0,x0), dot(x1,x1), dot(x2,x2), dot(x3,x3));
@@ -543,7 +523,7 @@ float psrdnoise(vec3 x, vec3 period, float alpha)
   return 39.5 * n;
 }
 
-float color(vec2 xy, float time_scale) { return psrdnoise(vec3(xy, time_scale * area_time), vec3(0,0,0), alpha * 0.3); }
+float color(vec2 xy, float time_scale) { return psrdnoise(vec3(xy, time_scale * area_time)); }
 
 float simplex_noise(vec2 xy, float noise_scale, vec2 step, float time_scale) {
     float x = 0;

--- a/source/source/core/shaders_source.cpp
+++ b/source/source/core/shaders_source.cpp
@@ -13,6 +13,7 @@
 
 namespace SHADER_SOURCES {
 
+
 #pragma region Default vertex shader
 
 


### PR DESCRIPTION
Onion shaders should now render at least 40% faster. This comes from reducing the amount of octaves the shader processes, and using a more recent simplex noise implementation. This implementation has not been ported to liquid shaders. 

The colormap on shaders now loop, preventing cases where half the screen could be filled with one of the end colors.