### PR TITLE
Gitignore now ignores all packs except the base pack.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,8 @@ allegro.log
 *.o
 *.d
 *.aps
-game_data/test/*
+game_data/*
+!game_data/base
 user_data/*
 easy_spat_nav_tests
 easy_analog_cleaner_tests


### PR DESCRIPTION
`base` should be the only pack that ships with a version release, so anything else shouldn't be tracked.