### PR TITLE
Change default value of `tint_random_maximum` to make more sense

### DIFF
--- a/manual/content/changelog.html
+++ b/manual/content/changelog.html
@@ -210,6 +210,7 @@
       <li>
         <a href="mob_type.html">Mob types</a>:
         <ul>
+          <li><span class="cl-c">Changed</span> the default value of a <a href="mob_decoration.html">decoration type</a> property <code>tint_random_maximum</code> from <code>0 0 0 0</code> to <code>255 255 255</code>.</li>
           <li><span class="cl-d">Deprecated</span> some <a href="mob_pellet.html">pellet type</a> properties: <code>match_seeds</code>, <code>non_match_seeds</code>. Please use <code>match_nutrients</code> and <code>non_match_nutrients</code> instead.</li>
           <li><span class="cl-r">Removed</span> a <a href="mob_pikmin.html">Pikmin type</a> property: <code>icon_onion</code>. Please use the new <code>icon</code> property of <a href="mob_onion.html">Onion types</a> and <a href="mob_ship.html">ship types</a>.</li>
         </ul>

--- a/manual/content/mob_decoration.html
+++ b/manual/content/mob_decoration.html
@@ -60,7 +60,7 @@
         <td>tint_random_maximum</td>
         <td>When an object of this type spawns, it will be tinted randomly. This property is the maximum tint that it can undergo, and the engine will pick a random color to tint it with between this color and full white (i.e. no tint). If you specify an alpha channel, the object's transparency will be decided randomly (but independently) too, between this value and 255 (full opacity).</td>
         <td>Color</td>
-        <td>0 0 0 0</td>
+        <td>255 255 255</td>
       </tr>
     </table>
 

--- a/source/source/content/mob_type/decoration_type.hpp
+++ b/source/source/content/mob_type/decoration_type.hpp
@@ -54,7 +54,7 @@ public:
     //--- Public members ---
     
     //Maximum amount it can deviate the tint by, for every color component.
-    ALLEGRO_COLOR tintRandomMaximum = COLOR_EMPTY;
+    ALLEGRO_COLOR tintRandomMaximum = COLOR_WHITE;
     
     //Maximum amount it can deviate the scale by.
     float scaleRandomVariation = 0.0f;


### PR DESCRIPTION
Now defaults to no tint, instead of fully transparent and black